### PR TITLE
Remove routing table compareandswap function

### DIFF
--- a/routingtable.go
+++ b/routingtable.go
@@ -34,7 +34,3 @@ func (t *atomicRoutingTable) Load() *routingTable {
 func (t *atomicRoutingTable) Store(new *routingTable) {
 	t.Value.Store(new)
 }
-
-func (t *atomicRoutingTable) CompareAndSwap(old, new *routingTable) bool {
-	return t.Value.CompareAndSwap(old, new)
-}


### PR DESCRIPTION
This function isn't used and forces us into requiring a go version of at least 1.19.