### PR TITLE
GOCBC-1498: Drop pool size to 1

### DIFF
--- a/routingclient.go
+++ b/routingclient.go
@@ -62,7 +62,7 @@ func DialContext(ctx context.Context, target string, opts *DialOptions) (*Routin
 
 	var conns []*routingConn
 
-	var poolSize uint32 = 3
+	var poolSize uint32 = 1
 	if opts.PoolSize > 0 {
 		poolSize = opts.PoolSize
 	}


### PR DESCRIPTION
Initial investigation showed that 3 connections performed better than 1 but this is no longer the case